### PR TITLE
Readme corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@
 Check releases tab for precompiled packages for Linux, Windows and Mac OS (experimental).   
 ### Manual:
 Alternatively you can run ArmCord from source (npm, nodejs required):    
-1.Clone ArmCord repo: `git clonehttps://github.com/ArmCord/ArmCord.git`    
-2.Run `npm install` to install dependencies   
-3.Compile/Package with `npm run package`    
+1. Clone ArmCord repo: `git clonehttps://github.com/ArmCord/ArmCord.git`    
+2. Run `npm install` to install dependencies   
+3. Compile/Package with `npm run package`    
 
 
 # FAQ
-## 1.Will I get banned from using it?   
+## 1. Will I get banned from using it?   
 
  -You are breaking Discord ToS if you decided to use client mods. But no one ever got banned from using ArmCord or any of the client mods included. If you wish to remove mods, check our documentation. 
-## 2.How does this work?   
+## 2. How does this work?   
 
  -We are using official web app and adding some magic powder to make it all work!   
-## 3.Can I use this on other architectures or operating systems?
+## 3. Can I use this on other architectures or operating systems?
 
  -Yes! ArmCord should work normally under Windows, ~~Mac OS~~ (Mac OS is broken see [#48](https://github.com/ArmCord/ArmCord/issues/48)) and Linux as long as it has NodeJS, npm and Electron support.   
 

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@
   
 # How to run/install it?
 ### Recommended:
-Check releases tab for precompiled packages for Linux, Windows and Mac OS (experimental).   
+ Check releases tab for precompiled packages for Linux, Windows and Mac OS (experimental).   
 ### Manual:
-Alternatively you can run ArmCord from source (npm, nodejs required):    
-1. Clone ArmCord repo: `git clonehttps://github.com/ArmCord/ArmCord.git`    
-2. Run `npm install` to install dependencies   
-3. Compile/Package with `npm run package`    
+ Alternatively you can run ArmCord from source (npm, nodejs required):    
+ 1. Clone ArmCord repo: `git clone https://github.com/ArmCord/ArmCord.git`    
+ 2. Run `npm install` to install dependencies   
+ 3. Compile/Package with `npm run package`    
 
 
 # FAQ

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
   
 # How to run/install it?
 ### Recommended:
- Check releases tab for precompiled packages for Linux, Windows and Mac OS (experimental).   
+ Check releases tab for precompiled packages for Linux, Windows and ~~Mac OS~~ (Mac OS is broken see [#48](https://github.com/ArmCord/ArmCord/issues/48)).   
 ### Manual:
  Alternatively you can run ArmCord from source (npm, nodejs required):    
  1. Clone ArmCord repo: `git clone https://github.com/ArmCord/ArmCord.git`    

--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
 
-<h1 align="center">
+<div align="center">
 <img src="https://armcord.vercel.app/armcord_full_logo.png" width="720">
-</h1>
-
-ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight. 
+ <br>ArmCord is a custom client designed to enhance your Discord experience while keeping everything lightweight. 
+</div>
 
 # Features
 
-* **Standalone client** - ArmCord is built as standalone client, it doesn't rely on original Discord client.
-* **Various mods built in** - Explore Cumcord/GooseMod/Flicker plugins and their features!
-* **Made for Privacy** - ArmCord automatically blocks Discord's trackers.
-* **Faster than normal Discord app** - ArmCord is using newer Electron than stock Discord app. This usually means increased performance and more stable experience.
-* **Designed to work anywhere** - ArmCord was initially created in mind to run on Arm64 Linux devices. We soon expanded our support to more platforms. We plan to support every platform that [Electron supports](https://www.electronjs.org/docs/latest/tutorial/support#supported-platforms).
+- **Standalone client** 
+
+   ArmCord is built as standalone client, it doesn't rely on original Discord client.
+
+
+- **Various mods built in**
+ 
+   Explore Cumcord/GooseMod/Flicker plugins and their features!
+
+
+- **Made for Privacy**
+
+   ArmCord automatically blocks Discord's trackers.
+
+
+- **Faster than normal Discord app**
+
+   ArmCord is using newer Electron than stock Discord app. This usually means increased performance and more stable experience.
+
+
+- **Designed to work anywhere**
+
+   ArmCord was initially created in mind to run on Arm64 Linux devices. We soon expanded our support to more platforms. We plan to support every platform that [Electron supports](https://www.electronjs.org/docs/latest/tutorial/support#supported-platforms).
+  
 # How to run/install it?
 ### Recommended:
 Check releases tab for precompiled packages for Linux, Windows and Mac OS (experimental).   


### PR DESCRIPTION
> Changes to landing section and title

This makes the landing section a bit more spaced out and easier to read, and makes the text to the bottom of the logo centered.

> Easier to read

Changes numbered lists to have as space between the numbers (1.Something -> 1. Something)

> Spelling mistake

`git clonehttps://...` -> `git clone https://...`
Also a few tab intendations