### PR TITLE
Fix app verion in tray

### DIFF
--- a/src/tray.ts
+++ b/src/tray.ts
@@ -26,6 +26,6 @@ app.whenReady().then(() => {
     },
   ]);
   
-  tray.setToolTip('ArmCord ' + process.env.npm_package_version)
+  tray.setToolTip('ArmCord ' + app.getVersion())
   tray.setContextMenu(contextMenu)
 })


### PR DESCRIPTION
Fixing app version displayed in system tray, because it displays `undefined` in built app
![firefox_iKnAmXhphu](https://user-images.githubusercontent.com/22046158/154756159-e12ce609-2a97-4f01-915d-4884a5dcf27c.png)
